### PR TITLE
V2.0.1 - minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TSO500 v2.0.0
+# eggd_TSO500 v2.1.0
 
 ## What does this app do?
 Runs the Illumina TSO500 local analysis app.

--- a/README.md
+++ b/README.md
@@ -289,10 +289,10 @@ output_folder/
 
 ## Notes
 - Samplesheet input is optional, if not specified the analysis app looks for the samplesheet in top level of runfolder
-- When running in scatter / gather mode, demultiplexing via the local app must always be first performed (i.e it can't be started from previously demultiplexed data and reusing fastqs) To achieve the equivalent, `-iupload_demultiplex_output=false` may be specified to not upload the output of demultiplexing from the job. When used in conjunction with `-iinclude_samples="sample1"`, this would effectively just run and output data for the given sample(s) as if the local app were just run from fastqs for a single sample
+- When running in scatter / gather mode, demultiplexing via the local app must always be first performed (i.e it can't be started from previously demultiplexed data and reusing fastqs). To achieve the equivalent, `-iupload_demultiplex_output=false` may be specified to not upload the output of demultiplexing from the job. When used in conjunction with `-iinclude_samples="sample1"`, this would effectively just run and output data for the given sample(s) as if the local app were just run from fastqs for a single sample
 - Jobs are launched per sample parsed from the 'Pair_ID' column, this means if the samplesheet is formatted for running in paired analysis mode, the fastqs for all samples for the given pair ID will be used for the analysis
 - sample names specified to `-iinclude_samples` or `-iexclude_samples` should be specified as given in the Pair_ID column of the samplesheet, or as regex pattern(s) which will be matched against the Pair_ID column
-- Intermediary genome vcfs found in `scatter/` are compressed before uploading to save on storage
+- Intermediary genome vcfs found in `scatter/` and `gather/Logs_Intermediates/` are compressed before uploading to save on storage
 - All log files are gathered up before uploading and combined into tar files, there is one tar file per file from the scatter step and one from the gather step. This is to reduce the total number of files uploaded at the end.
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eggd_TSO500 v2.1.0
+# eggd_TSO500
 
 ## What does this app do?
 Runs the Illumina TSO500 local analysis app.

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "eggd_tso500",
   "summary": "Somatic variant calling for DNA & RNA samples using TSO500 local app",
   "dxapi": "1.0.0",
-  "version":"2.0.0",
+  "version":"2.1.0",
   "openSource": true,
   "inputSpec": [
     {

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "eggd_tso500",
   "summary": "Somatic variant calling for DNA & RNA samples using TSO500 local app",
   "dxapi": "1.0.0",
-  "version":"2.1.0",
+  "version":"2.0.1",
   "openSource": true,
   "inputSpec": [
     {

--- a/src/code.sh
+++ b/src/code.sh
@@ -488,7 +488,8 @@ _upload_final_output() {
 
     # compress intermediate genome VCFs since we don't use these routinely
     # and they go from >300mb to < 10mb (plus its a vcf, it should be compressed)
-    find "/home/dnanexus/out/scatter/" -type f -name "*.vcf"  -exec gzip {} \;
+    find "/home/dnanexus/out/scatter/" -type f -name "*.vcf"  -print0 \
+        | xargs -I{} -n1 -P "$THREADS" gzip {}
 
     # upload final run level MetricsOutput.tsv as distinct output field
     metrics_file_id=$(dx upload -p /home/dnanexus/out/gather/Results/MetricsOutput.tsv --brief)

--- a/src/code.sh
+++ b/src/code.sh
@@ -488,7 +488,8 @@ _upload_final_output() {
 
     # compress intermediate genome VCFs since we don't use these routinely
     # and they go from >300mb to < 10mb (plus its a vcf, it should be compressed)
-    find "/home/dnanexus/out/scatter/" -type f -name "*.vcf"  -print0 \
+    time find /home/dnanexus/out/scatter/ /home/dnanexus/out/gather/Logs_Intermediates/ \
+        -type f -name "*.vcf"  -print0 \
         | xargs -I{} -n1 -P "$THREADS" gzip {}
 
     # upload final run level MetricsOutput.tsv as distinct output field

--- a/src/code.sh
+++ b/src/code.sh
@@ -348,8 +348,7 @@ _upload_single_file() {
   file_id=$(dx upload "$file" --path "$remote_path" --parents --brief)
 
   if [[ "$link" == true ]]; then
-    # flock here ensures we don't try write to the dxoutput.json when uploading in parallel
-    flock -x -w30 /tmp/add_output.lock dx-jobutil-add-output "$field" "$file_id" --array
+    dx-jobutil-add-output "$field" "$file_id" --array
   fi
 }
 
@@ -487,11 +486,11 @@ _upload_final_output() {
         xargs -n1 -I{} mv {} /tmp <<< $files
     done
 
-    # compress intermediate genome VCFs since we don't use these routinely
-    # and they go from >300mb to < 10mb (plus its a vcf, it should be compressed)
+    # compress intermediate VCFs since we don't use these routinely and
+    # they go from >300mb to < 10mb (plus its a vcf, it should be compressed)
     time find /home/dnanexus/out/scatter/ /home/dnanexus/out/gather/Logs_Intermediates/ \
         -type f -name "*.vcf"  -print0 \
-        | xargs -I{} -n1 -P "$THREADS" gzip {}
+        | xargs --null -I{} -n1 -P "$THREADS" gzip {}
 
     # upload final run level MetricsOutput.tsv as distinct output field
     metrics_file_id=$(dx upload -p /home/dnanexus/out/gather/Results/MetricsOutput.tsv --brief)


### PR DESCRIPTION
- fix for more robustly handling uploading job outputs due to bug in `dx-jobutil-add-output`
  - fixes #19 
- add parallelised compression of final intermediate VCFs
  - fixes #18 
  - fixes #20
- test job: https://platform.dnanexus.com/panx/projects/GgBKvf84Fg5xQQZqBFXQFF3j/monitor/job/GgBKyQ84Fg5vvfPG9bvV9JBk

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_tso500/21)
<!-- Reviewable:end -->
